### PR TITLE
Assign MediaEvents MessageType of Media

### DIFF
--- a/mParticle-Apple-Media-SDK/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK/MPMediaSDK.swift
@@ -714,6 +714,7 @@ let PlayerOvp = "player_ovp"
         self.mediaSessionId = session.mediaSessionId
         
         super.init(eventType: .media)
+        self.messageType = MPMessageType.media
         
         self.customAttributes = options?.customAttributes
         if (options?.currentPlayheadPosition != nil) {

--- a/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
+++ b/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
@@ -16,6 +16,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
             self._mediaEventHandler = newValue
             self._mediaEventExpectation = self.expectation(description: "MediaSession event listener")
             self.mediaSession?.mediaEventListener = { (event: MPMediaEvent) -> Void in
+                XCTAssertEqual(event.messageType, MPMessageType.media)
                 mediaHandler(event)
                 self._mediaEventExpectation?.fulfill()
                 
@@ -36,6 +37,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
             }
             self._coreMediaEventExpectation = self.expectation(description: "Core SDK MediaEvent Listener")
             self._coreMediaEventHandler = { (event: MPMediaEvent) -> Void in
+                XCTAssertEqual(event.messageType, MPMessageType.media)
                 mediaEventHandler(event)
                 self._coreMediaEventExpectation?.fulfill()
             }
@@ -56,6 +58,8 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
             }
             self._coreMPEventExpectation = self.expectation(description: "Core SDK MPEvent Listener")
                 self._coreMPEventHandler = { (event: MPEvent) -> Void in
+                    XCTAssertEqual(event.type, MPEventType.media)
+                    XCTAssertEqual(event.messageType, MPMessageType.event)
                     mpEventHandler(event)
                     self._coreMPEventExpectation?.fulfill()
                 }


### PR DESCRIPTION
# Summary

So, this took me longer than it should have, but I realized that we are actually generating MediaEvents with the incorrect MessageType in the Media SDK. Previously we used MessageType.Unknown which is filtered out across the board in the KitContainer logic. I tried a bunch of stuff in the core SDK before realizing it was as simple as just setting the proper MessageType, MPMessageType.Media

## Tests

I updated the unit tests so that we are checking that every single MediaEvent is created with MessageType == MPMessageType.media and that every single MPEvent is created with eventType == MPEventType.media and MessageType == MPMessageType.event (just to be safe)

## Issue 
closes: https://go.mparticle.com/work/63735
