### PR TITLE
Add fix for xcode 12 and swift 5.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,9 +2,15 @@
 
 import PackageDescription
 
+#if swift(>=5.3)
+let ios = SupportedPlatform.iOS(.v9)
+#else
+let ios = SupportedPlatform.iOS(.v8)
+#endif
+
 let package = Package(
     name: "mParticle-Apple-Media-SDK",
-    platforms: [ .iOS(.v8), .tvOS(.v9) ],
+    platforms: [ ios, .tvOS(.v9) ],
     products: [
         .library(
             name: "mParticle-Apple-Media-SDK",


### PR DESCRIPTION
Swift 5.3 does not support iOS 8 anymore and therefore Xcode 12 (using Swift 5.3) will print a 'IPHONEOS_DEPLOYMENT_TARGET' warning. Also Addresses the following error when integrating with core SDKv 8.5.0:

<img width="1357" alt="Screen Shot 2021-08-10 at 2 30 28 PM" src="https://user-images.githubusercontent.com/19657993/128928786-bab6c4fc-54d5-4c54-be9e-c33e85fc6a2f.png">

