### PR TITLE
feat: Add custom name option for MediaEvent

### DIFF
--- a/mParticle-Apple-Media-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-Media-SDK.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B2F9AC482613949600926C7C /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBC7002A2319AAF900981B75 /* mParticle_Apple_SDK.framework */; };
-		DB7CA49E23205CD900F1C47B /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBC7002A2319AAF900981B75 /* mParticle_Apple_SDK.framework */; };
+		53522078278E1AD100684F0B /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53522077278E1AD100684F0B /* mParticle_Apple_SDK.framework */; };
+		53522079278E1AD100684F0B /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53522077278E1AD100684F0B /* mParticle_Apple_SDK.framework */; };
 		DBD815F22319A7F500A9809C /* mParticle_Apple_Media_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBD815E82319A7F400A9809C /* mParticle_Apple_Media_SDK.framework */; };
 		DBD815F72319A7F500A9809C /* mParticle_Apple_MediaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD815F62319A7F500A9809C /* mParticle_Apple_MediaTests.swift */; };
 		DBD815F92319A7F500A9809C /* mParticle_Apple_Media_SDK.h in Headers */ = {isa = PBXBuildFile; fileRef = DBD815EB2319A7F400A9809C /* mParticle_Apple_Media_SDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -26,7 +26,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		DBC7002A2319AAF900981B75 /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = mParticle_Apple_SDK.framework; path = "/Users/wpassidomo/Documents/media-sdk-apple/Carthage/Build/iOS/mParticle_Apple_SDK.framework"; sourceTree = "<absolute>"; };
+		53522077278E1AD100684F0B /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = mParticle_Apple_SDK.framework; path = Carthage/Build/iOS/mParticle_Apple_SDK.framework; sourceTree = "<group>"; };
 		DBD815E82319A7F400A9809C /* mParticle_Apple_Media_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Apple_Media_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DBD815EB2319A7F400A9809C /* mParticle_Apple_Media_SDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mParticle_Apple_Media_SDK.h; sourceTree = "<group>"; };
 		DBD815EC2319A7F400A9809C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -41,7 +41,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B2F9AC482613949600926C7C /* mParticle_Apple_SDK.framework in Frameworks */,
+				53522078278E1AD100684F0B /* mParticle_Apple_SDK.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -50,7 +50,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DBD815F22319A7F500A9809C /* mParticle_Apple_Media_SDK.framework in Frameworks */,
-				DB7CA49E23205CD900F1C47B /* mParticle_Apple_SDK.framework in Frameworks */,
+				53522079278E1AD100684F0B /* mParticle_Apple_SDK.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -67,7 +67,7 @@
 		DBD815DE2319A7F400A9809C = {
 			isa = PBXGroup;
 			children = (
-				DBC7002A2319AAF900981B75 /* mParticle_Apple_SDK.framework */,
+				53522077278E1AD100684F0B /* mParticle_Apple_SDK.framework */,
 				DBD815EA2319A7F400A9809C /* mParticle-Apple-Media-SDK */,
 				DBD815F52319A7F500A9809C /* mParticle-Apple-Media-SDKTests */,
 				DBD815E92319A7F400A9809C /* Products */,

--- a/mParticle-Apple-Media-SDK/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK/MPMediaSDK.swift
@@ -688,6 +688,7 @@ let PlayerOvp = "player_ovp"
 
     // MARK: specialized
     // Properties only applicable to certain kinds of events
+    @objc public var customEventName: String?
     @objc public var adContent: MPMediaAdContent?
     @objc public var segment: MPMediaSegment?
     @objc public var adBreak: MPMediaAdBreak?
@@ -724,6 +725,11 @@ let PlayerOvp = "player_ovp"
         }
     }
     
+    @objc public convenience init?(customName: String, session: MPMediaSession, options: Options? = nil) {
+        self.init(name: MPMediaEventName.custom, session: session, options: options)
+        self.customEventName = customName
+    }
+    
     internal init?(name: MPMediaEventName, title: String, mediaContentId: String, duration: NSNumber?, contentType: MPMediaContentType, streamType: MPMediaStreamType, mediaSessionId: String, options: Options) {
         self.mediaEventName = name
         self.mediaContentTitle = title
@@ -742,6 +748,7 @@ let PlayerOvp = "player_ovp"
     @objc public override func isEqual(_ object: Any?) -> Bool {
         if let object = object as? MPMediaEvent {
             return (self.mediaEventName == object.mediaEventName &&
+                self.customEventName == object.customEventName &&
                 self.mediaContentTitle == object.mediaContentTitle &&
                 self.mediaContentId == object.mediaContentId &&
                 self.duration == object.duration &&
@@ -769,6 +776,7 @@ let PlayerOvp = "player_ovp"
         
         let object: MPMediaEvent? = MPMediaEvent(name: self.mediaEventName, title: self.mediaContentTitle, mediaContentId: mediaContentId, duration: duration, contentType: contentType, streamType: streamType, mediaSessionId: mediaSessionId, options: options)
         if let object = object {
+            object.customEventName = self.customEventName
             object.adContent = self.adContent
             object.segment = self.segment
             object.adBreak = self.adBreak
@@ -785,9 +793,14 @@ let PlayerOvp = "player_ovp"
     }
 
     @objc public func toMPEvent() -> MPEvent {
-        let eventNameString = MPMediaEvent.mediaEventTypeString(mediaEventType: self.mediaEventName)
-        let mpEvent = MPEvent.init(name: eventNameString, type: .media)
-        mpEvent?.customAttributes = self.getEventAttributes()
+        let eventNameString: String
+        if let customEventName = customEventName, mediaEventName == .custom {
+            eventNameString = customEventName
+        } else {
+            eventNameString = MPMediaEvent.mediaEventTypeString(mediaEventType: mediaEventName)
+        }
+        let mpEvent = MPEvent(name: eventNameString, type: .media)
+        mpEvent?.customAttributes = getEventAttributes()
                 
         return mpEvent!
     }
@@ -936,6 +949,7 @@ let PlayerOvp = "player_ovp"
 /// The type of a media event--this is set internally by the Media SDK on media event objects before forwarding to the core SDK.
 /// (You generally won't need this unless you need to call logBaseEvent for some reason.)
 @objc public enum MPMediaEventName: Int, RawRepresentable {
+    
     case play = 23
     case pause = 24
     case contentEnd = 25
@@ -959,6 +973,7 @@ let PlayerOvp = "player_ovp"
     case milestone = 47
     case sessionSummary = 48
     case adSessionSummary = 49
+    case custom = 50
 }
 
 public enum MPMediaEventNameString: String, RawRepresentable {

--- a/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
+++ b/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 @testable import mParticle_Apple_Media_SDK
 
+private let defaultTimeout = 10.0
+
 class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
     var coreSDK: MParticle?
     var mediaSession: MPMediaSession?
@@ -121,8 +123,17 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         XCTAssertEqual(mediaEvent2?.duration?.intValue, 80000)
         XCTAssertEqual(mediaEvent2?.contentType, .audio)
         XCTAssertEqual(mediaEvent2?.streamType, .liveStream)
+         
+        let customName = "some custom name"
+        let customMediaEvent = MPMediaEvent(customName: customName, session: mediaSession!, options: nil)
+        let customMPEvent = customMediaEvent?.toMPEvent()
+        
+        XCTAssertEqual(customMediaEvent?.customEventName, customName)
+        XCTAssertEqual(customMediaEvent?.mediaEventName, .custom)
+        XCTAssertEqual(customMPEvent?.name, customName)
+        XCTAssertEqual(customMPEvent?.type, .media)
     }
-
+    
     func testLogMediaSessionStart() {
         let mediaHandler = { (event: MPMediaEvent) -> Void in
             XCTAssertEqual(event.mediaEventName, .sessionStart)
@@ -131,7 +142,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
 
         mediaSession?.logMediaSessionStart()
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testLogMediaSessionStartWithOptions() {
@@ -152,7 +163,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logMediaSessionStart(options: option)
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testLogMediaSessionStartAlternet() {
@@ -167,7 +178,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         }
         
         mediaSession?.logMediaSessionStart()
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogMediaSessionEnd() {
@@ -178,7 +189,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logMediaSessionEnd()
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogMediaContentEnd() {
@@ -189,7 +200,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logMediaContentEnd()
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogPlay() {
@@ -200,7 +211,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logPlay()
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testLogPlayWithExistingPlayhead() {
@@ -213,7 +224,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         
         mediaSession?.currentPlayheadPosition = 1400
         mediaSession?.logPlay()
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testLogPlayWithOptions() {
@@ -230,7 +241,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logPlay(options: options)
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogPause() {
@@ -241,7 +252,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logPause()
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
     
     func testLogPauseWithOptions() {
@@ -258,7 +269,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logPause(options: options)
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogSeekStart() {
@@ -270,7 +281,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logSeekStart(position: 20000)
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogSeekEnd() {
@@ -282,7 +293,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logSeekEnd(position: 30000)
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogAdStart() {
@@ -298,7 +309,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logAdStart(adContent: adContent)
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogAdEnd() {
@@ -309,7 +320,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logAdEnd()
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogAdClick() {
@@ -320,7 +331,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logAdClick()
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogAdSkip() {
@@ -331,7 +342,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logAdSkip()
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogAdBreakStart() {
@@ -346,7 +357,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logAdBreakStart(adBreak: adBreak)
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogAdBreakEnd() {
@@ -357,7 +368,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logAdBreakEnd()
-        self.await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogSegmentStart() {
@@ -371,7 +382,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logSegmentStart(segment: segment)
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogSegmentEnd() {
@@ -382,7 +393,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logSegmentEnd()
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogSegmentSkip() {
@@ -393,7 +404,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logSegmentSkip()
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogPlayheadPosition() {
@@ -405,7 +416,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         self.coreMediaEventHandler = mediaHandler
         
         mediaSession?.logPlayheadPosition(position: 45000)
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func testLogQoS() {
@@ -425,7 +436,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         qos.fps = 60
         qos.startupTime = 2000
         mediaSession?.logQoS(metadata: qos)
-        await()
+        self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
     func onAPICalled(_: String, stackTrace: [Any], isExternal: Bool, objects: [Any]?) {
@@ -452,9 +463,5 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
                 eventHandler(first)
             }
         }
-    }
-    
-    private func await() {
-        self.waitForExpectations(timeout: 10, handler: nil)
     }
 }


### PR DESCRIPTION
# Summary

- Brings functionality in line with Android
- Fixed unit tests in latest Xcode version (`await` is now a reserved keyword due to new async/await functionality in Swift)
