### PR TITLE
Addressing bug that only creates media sessions with video

### DIFF
--- a/mParticle-Apple-Media-SDK/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK/MPMediaSDK.swift
@@ -813,7 +813,7 @@ let PlayerOvp = "player_ovp"
         sessionAttributes[MediaAttributeKeysContentId] = mediaContentId
         sessionAttributes[MediaAttributeKeysDuration] = duration?.stringValue
         sessionAttributes[MediaAttributeKeysStreamType] = MPMediaEvent.mediaStreamTypeString(mediaStreamType:streamType);
-        sessionAttributes[MediaAttributeKeysContentType] = (contentType == MPMediaContentType.video) ? MPMediaContentTypeString.video.rawValue : MPMediaContentTypeString.video.rawValue
+        sessionAttributes[MediaAttributeKeysContentType] = (contentType == MPMediaContentType.video) ? MPMediaContentTypeString.video.rawValue : MPMediaContentTypeString.audio.rawValue
         
         return sessionAttributes
     }


### PR DESCRIPTION
Noticed today that no matter what contentType i put (audio or video), it always created the session with video. Upon further inspection i noticed the conditional on line 816 (at the time of this posting), assigned video to both conditions. I made this same edit locally and it works fine now but obviously dont know what other sorts of regression tests may need to happen given this change.

## Summary
- edited the line that assigned video to both conditions to use audio for the false condition (i.e. if video is not the selected option)

## Testing Plan
- initial tests locally for a simple session worked but again not sure what typical tests need to be done for a change like this

## Reference Issue
- Closes https://go.mparticle.com/work/REPLACEME