### PR TITLE
fix: Handle 0 Duration

### DIFF
--- a/mParticle-Apple-Media-SDK/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK/MPMediaSDK.swift
@@ -364,7 +364,7 @@ let PlayerOvp = "player_ovp"
     @objc func logEvent(mediaEvent: MPMediaEvent) {
         self.mediaSessionEndTimestamp = Date()
         if (self.mediaContentCompleteLimit != 100) {
-            if ((duration != nil) && (self.currentPlayheadPosition?.intValue ?? 0)/duration!.intValue > (self.mediaContentCompleteLimit/100)) {
+            if ((duration != nil) && (duration!.intValue != 0) && (self.currentPlayheadPosition?.intValue ?? 0)/duration!.intValue > (self.mediaContentCompleteLimit/100)) {
                 self.mediaContentComplete = true
             }
         }

--- a/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
+++ b/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
@@ -503,4 +503,32 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
             }
         }
     }
+    
+    func testEmptyDuration() {
+        XCTAssertNotNil(mediaSession)
+        
+        mediaSession?.duration = 0;
+        let mediaEvent1 = mediaSession?.makeMediaEvent(name: .play)
+        mediaSession?.logEvent(mediaEvent: mediaEvent1!)
+        
+        XCTAssertEqual(mediaEvent1?.mediaEventName, .play)
+        XCTAssertEqual(mediaEvent1?.mediaContentId, "12345")
+        XCTAssertEqual(mediaEvent1?.mediaContentTitle, "foo title")
+        XCTAssertEqual(mediaEvent1?.duration?.intValue, 0)
+        XCTAssertEqual(mediaEvent1?.contentType, .video)
+        XCTAssertEqual(mediaEvent1?.streamType, .onDemand)
+        XCTAssertTrue(mediaEvent1?.customAttributes == nil)
+
+        mediaSession?.duration = nil;
+        let mediaEvent2 = mediaSession?.makeMediaEvent(name: .play)
+        mediaSession?.logEvent(mediaEvent: mediaEvent2!)
+
+        XCTAssertEqual(mediaEvent1?.mediaEventName, .play)
+        XCTAssertEqual(mediaEvent1?.mediaContentId, "12345")
+        XCTAssertEqual(mediaEvent1?.mediaContentTitle, "foo title")
+        XCTAssertEqual(mediaEvent1?.duration?.intValue, 0)
+        XCTAssertEqual(mediaEvent1?.contentType, .video)
+        XCTAssertEqual(mediaEvent1?.streamType, .onDemand)
+        XCTAssertTrue(mediaEvent1?.customAttributes == nil)
+    }
 }


### PR DESCRIPTION
## Summary
 - While working on the mParticle implementation on Sky, we found out a crash can happen if we start the MPMediaSession object with a duration of 0. This is due to the code on line: https://github.com/mParticle/mparticle-apple-media-sdk/blob/master/mParticle-Apple-Media-SDK/MPMediaSDK.swift#L367 

This code handles a nil duration, but if it's 0, it will cause a math inconsistency (dividing by 0), which causes a crash on the app.

 ## Testing Plan
 - Tested locally, through unit tests, and confirmed in livestream.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5457
