### PR TITLE
feat: Add iOS 17 Privacy Manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 .build/
+Package.resolved
 
 # CocoaPods
 #

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "mparticle/mparticle-apple-sdk" ~> 8.0
+binary "https://raw.githubusercontent.com/mParticle/mparticle-apple-sdk/main/mParticle_Apple_SDK.json" ~> 8.22

--- a/Package.swift
+++ b/Package.swift
@@ -2,15 +2,9 @@
 
 import PackageDescription
 
-#if swift(>=5.3)
-let ios = SupportedPlatform.iOS(.v9)
-#else
-let ios = SupportedPlatform.iOS(.v8)
-#endif
-
 let package = Package(
     name: "mParticle-Apple-Media-SDK",
-    platforms: [ ios, .tvOS(.v9) ],
+    platforms: [ .iOS(.v9), .tvOS(.v9) ],
     products: [
         .library(
             name: "mParticle-Apple-Media-SDK",
@@ -19,18 +13,18 @@ let package = Package(
     dependencies: [
         .package(name: "mParticle-Apple-SDK",
             url: "https://github.com/mParticle/mparticle-apple-sdk",
-            .upToNextMajor(from: "8.0.0")),
+            .upToNextMajor(from: "8.22.0")),
     ],
     targets: [
         .target(
-        name: "mParticle-Apple-Media-SDK",
-        dependencies: [
-            "mParticle-Apple-SDK"
-        ],
-        path: "mParticle-Apple-Media-SDK",
-        cSettings: [
-            CSetting.headerSearchPath("./**"),
-            .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release))
-        ]),
+            name: "mParticle-Apple-Media-SDK",
+            dependencies: [
+                "mParticle-Apple-SDK"
+            ],
+            path: "mParticle-Apple-Media-SDK",
+            exclude: ["Info.plist"],
+            resources: [.process("PrivacyInfo.xcprivacy")],
+            publicHeadersPath: "."
+        )
     ]
 )

--- a/mParticle-Apple-Media-SDK.podspec
+++ b/mParticle-Apple-Media-SDK.podspec
@@ -18,5 +18,6 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.tvos.deployment_target = "9.0"
     s.source_files      = 'mParticle-Apple-Media-SDK/*.{h,swift}'
-    s.dependency 'mParticle-Apple-SDK', '~> 8.0'
+    s.ios.resource_bundles  = { 'mParticle-Apple-Media-SDK-Privacy' => ['mParticle-Apple-Media-SDK/PrivacyInfo.xcprivacy'] }
+    s.dependency 'mParticle-Apple-SDK', '~> 8.22'
 end

--- a/mParticle-Apple-Media-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-Media-SDK.xcodeproj/project.pbxproj
@@ -3,12 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		53522078278E1AD100684F0B /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53522077278E1AD100684F0B /* mParticle_Apple_SDK.framework */; };
-		53522079278E1AD100684F0B /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53522077278E1AD100684F0B /* mParticle_Apple_SDK.framework */; };
+		53034BFE2BEC056C00AA62CE /* mParticle_Apple_SDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53034BFD2BEC056C00AA62CE /* mParticle_Apple_SDK.xcframework */; };
+		53034BFF2BEC056C00AA62CE /* mParticle_Apple_SDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53034BFD2BEC056C00AA62CE /* mParticle_Apple_SDK.xcframework */; };
 		DBD815F22319A7F500A9809C /* mParticle_Apple_Media_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBD815E82319A7F400A9809C /* mParticle_Apple_Media_SDK.framework */; };
 		DBD815F72319A7F500A9809C /* mParticle_Apple_MediaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD815F62319A7F500A9809C /* mParticle_Apple_MediaTests.swift */; };
 		DBD815F92319A7F500A9809C /* mParticle_Apple_Media_SDK.h in Headers */ = {isa = PBXBuildFile; fileRef = DBD815EB2319A7F400A9809C /* mParticle_Apple_Media_SDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -26,7 +26,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		53522077278E1AD100684F0B /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = mParticle_Apple_SDK.framework; path = Carthage/Build/iOS/mParticle_Apple_SDK.framework; sourceTree = "<group>"; };
+		53034BFD2BEC056C00AA62CE /* mParticle_Apple_SDK.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:DLD43Y3TRP:mParticle, inc"; lastKnownFileType = wrapper.xcframework; name = mParticle_Apple_SDK.xcframework; path = Carthage/Build/mParticle_Apple_SDK.xcframework; sourceTree = "<group>"; };
 		DBD815E82319A7F400A9809C /* mParticle_Apple_Media_SDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Apple_Media_SDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DBD815EB2319A7F400A9809C /* mParticle_Apple_Media_SDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mParticle_Apple_Media_SDK.h; sourceTree = "<group>"; };
 		DBD815EC2319A7F400A9809C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -41,7 +41,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				53522078278E1AD100684F0B /* mParticle_Apple_SDK.framework in Frameworks */,
+				53034BFE2BEC056C00AA62CE /* mParticle_Apple_SDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -50,7 +50,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DBD815F22319A7F500A9809C /* mParticle_Apple_Media_SDK.framework in Frameworks */,
-				53522079278E1AD100684F0B /* mParticle_Apple_SDK.framework in Frameworks */,
+				53034BFF2BEC056C00AA62CE /* mParticle_Apple_SDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -67,7 +67,7 @@
 		DBD815DE2319A7F400A9809C = {
 			isa = PBXGroup;
 			children = (
-				53522077278E1AD100684F0B /* mParticle_Apple_SDK.framework */,
+				53034BFD2BEC056C00AA62CE /* mParticle_Apple_SDK.xcframework */,
 				DBD815EA2319A7F400A9809C /* mParticle-Apple-Media-SDK */,
 				DBD815F52319A7F500A9809C /* mParticle-Apple-Media-SDKTests */,
 				DBD815E92319A7F400A9809C /* Products */,

--- a/mParticle-Apple-Media-SDK/PrivacyInfo.xcprivacy
+++ b/mParticle-Apple-Media-SDK/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+</dict>
+</plist>


### PR DESCRIPTION
 ## Summary
 - Add privacy manifest
 - Confirm inclusion in all 3 package managers
 - Clean up Package.swift file

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Confirmed in test apps

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6413