### PR TITLE
fix:Convert Media Session Timestamps to UNIX

### DIFF
--- a/mParticle-Apple-Media-SDK/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK/MPMediaSDK.swift
@@ -597,8 +597,8 @@ let PlayerOvp = "player_ovp"
             let mediaEvent = self.makeMediaEvent(name: .sessionSummary, options: nil)
             
             var customAttributes: [String:Any] = mediaEvent.getEventAttributes()
-            customAttributes[startTimestampKey] = self.mediaSessionStartTimestamp
-            customAttributes[endTimestampKey] = self.mediaSessionEndTimestamp
+            customAttributes[startTimestampKey] = Int(self.mediaSessionStartTimestamp.timeIntervalSince1970  * 1_000)
+            customAttributes[endTimestampKey] = Int(self.mediaSessionEndTimestamp.timeIntervalSince1970  * 1_000)
             customAttributes[contentIdKey] = self.mediaContentId
             customAttributes[contentTitleKey] = self.title
             customAttributes[mediaTimeSpentKey] = self.mediaTimeSpent


### PR DESCRIPTION
 ## Summary
 - The current format of the media session timestamps for both Start and End are coming in as date format as opposed to every timestamp being UNIX. The fix here is to convert the incoming Media Session Start Time and Media Session End Time to UNIX.
 
 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - The local pod for the iOS media SDK was changed with the code in this fix and verified that it's showing in livestream as UNIX timestamp

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - https://mparticle-eng.atlassian.net/browse/PRODRDMP-6972