### PR TITLE
fix: pause mediaConentTimeSpent when logMediaContentEnd is triggered

### DIFF
--- a/mParticle-Apple-Media-SDK/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK/MPMediaSDK.swift
@@ -403,6 +403,8 @@ let PlayerOvp = "player_ovp"
     /// Denotes that the playhead position has reached the final position in the content
     @objc public func logMediaContentEnd(options: Options?  = nil) {
         self.mediaContentComplete = true
+        self.storedPlaybackTime = self.storedPlaybackTime + Date().timeIntervalSince(self.currentPlaybackStartTimestamp ?? Date())
+        self.currentPlaybackStartTimestamp = nil;
         
         let mediaEvent = self.makeMediaEvent(name: .contentEnd, options: options)
         self.logEvent(mediaEvent: mediaEvent)

--- a/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
+++ b/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
@@ -531,4 +531,34 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         XCTAssertEqual(mediaEvent1?.streamType, .onDemand)
         XCTAssertTrue(mediaEvent1?.customAttributes == nil)
     }
+    
+    func testMediaTimeSpentWhenLogMediaContentEndCalled() {
+        XCTAssertNotNil(mediaSession)
+        
+        // logPlay is triggered to start media content time tracking.
+        mediaSession?.logPlay()
+        // 0.1s delay added to account for the time spent on media content.
+        Thread.sleep(forTimeInterval: 0.1)
+        mediaSession?.logMediaContentEnd()
+        // Another 0.1s delay added after logMediaContentEnd is triggered to
+        // account for time spent on media session (total = +0.2s).
+        Thread.sleep(forTimeInterval: 0.1)
+        mediaSession?.logMediaSessionEnd()
+
+        let mediaSessionContentTimeSpent = mediaSession?.mediaContentTimeSpent ?? 0.0
+        let mediaSessionTimeSpent = mediaSession?.mediaTimeSpent ?? 0.0
+        
+        XCTAssertNotEqual(mediaSessionContentTimeSpent, mediaSessionTimeSpent)
+        
+        // the mediaContentTimeSpent varies in value each test run by a millisecond or two (i,e value is could be 0.101s,
+        // 0.103s, 0.105s) and we can't determine the exact value, hence the greaterThanOrEqual and lessThanOrEqual tests.
+        XCTAssertGreaterThanOrEqual(mediaSessionContentTimeSpent, 0.1)
+        XCTAssertLessThanOrEqual(mediaSessionContentTimeSpent, 0.2)
+        
+        // the mediaTimeSpent varies in value each test run by a millisecond or two (i,e value is could be 0.201s,
+        // 0.203s, 0.205s and we can't determine the exact value, hence the greaterThanOrEqual and lessThanOrEqual tests.
+        XCTAssertGreaterThanOrEqual(mediaSessionTimeSpent, 0.2)
+        XCTAssertLessThanOrEqual(mediaSessionTimeSpent, 0.3)
+        
+    }
 }

--- a/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
+++ b/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
@@ -561,4 +561,34 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         XCTAssertLessThanOrEqual(mediaSessionTimeSpent, 0.3)
         
     }
+    
+    func testMediaTimeSpentWhenLogPauseCalled() {
+        XCTAssertNotNil(mediaSession)
+        
+        // logPlay is triggered to start media content time tracking.
+        mediaSession?.logPlay()
+        // 0.1s delay added to account for the time spent on media content.
+        Thread.sleep(forTimeInterval: 0.1)
+        mediaSession?.logPause()
+        // Another 0.1s delay added after logPause is triggered to
+        // account for time spent on media session (total = +0.2s).
+        Thread.sleep(forTimeInterval: 0.1)
+        mediaSession?.logMediaSessionEnd()
+
+        let mediaSessionContentTimeSpent = mediaSession?.mediaContentTimeSpent ?? 0.0
+        let mediaSessionTimeSpent = mediaSession?.mediaTimeSpent ?? 0.0
+        
+        XCTAssertNotEqual(mediaSessionContentTimeSpent, mediaSessionTimeSpent)
+        
+        // the mediaContentTimeSpent varies in value each test run by a millisecond or two (i,e value is could be 0.101s,
+        // 0.103s, 0.105s) and we can't determine the exact value, hence the greaterThanOrEqual and lessThanOrEqual tests.
+        XCTAssertGreaterThanOrEqual(mediaSessionContentTimeSpent, 0.1)
+        XCTAssertLessThanOrEqual(mediaSessionContentTimeSpent, 0.2)
+        
+        // the mediaTimeSpent varies in value each test run by a millisecond or two (i,e value is could be 0.201s,
+        // 0.203s, 0.205s and we can't determine the exact value, hence the greaterThanOrEqual and lessThanOrEqual tests.
+        XCTAssertGreaterThanOrEqual(mediaSessionTimeSpent, 0.2)
+        XCTAssertLessThanOrEqual(mediaSessionTimeSpent, 0.3)
+        
+    }
 }


### PR DESCRIPTION
 ## Summary
 - When a logMediaContentEnd event is called, it does not stop the counter for mediaContentTimeSpent Therefore, even when the consumer finishes content but doesn't complete the media session, the mediaContentTimeSpent counter increases. Currently, only logPause and logMediaSessionEnd will stop the mediaContentTimeSpent counter. This pr is to allow the mediaContentTimeSpent to be paused when a logMediaContentEnd is triggered

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E and unit tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7166
