### PR TITLE
feat: calculate mediaTimeSpent based on current time

### DIFF
--- a/mParticle-Apple-Media-SDK/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK/MPMediaSDK.swift
@@ -242,7 +242,7 @@ let PlayerOvp = "player_ovp"
     private(set) public var mediaSessionEndTimestamp: Date //Timestamp updated when any event is loggged
     public var mediaTimeSpent: Double {
         get { //total seconds between media session start and end time
-            return self.mediaSessionEndTimestamp.timeIntervalSince(mediaSessionStartTimestamp)
+            return Date().timeIntervalSince(mediaSessionStartTimestamp)
         }
     }
     public var mediaContentTimeSpent: Double {

--- a/mParticle-Apple-Media-SDK/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK/MPMediaSDK.swift
@@ -241,7 +241,7 @@ let PlayerOvp = "player_ovp"
     private(set) public var mediaSessionStartTimestamp: Date //Timestamp created on logMediaSessionStart event
     private(set) public var mediaSessionEndTimestamp: Date //Timestamp updated when any event is loggged
     public var mediaTimeSpent: Double {
-        get { //total seconds between media session start and end time
+        get { //total seconds between media session start and current timestamp
             return Date().timeIntervalSince(mediaSessionStartTimestamp)
         }
     }

--- a/mParticle-Apple-Media-SDK/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK/MPMediaSDK.swift
@@ -239,7 +239,7 @@ let PlayerOvp = "player_ovp"
     @objc public var mediaEventListener: ((MPMediaEvent)->Void)?
     
     private(set) public var mediaSessionStartTimestamp: Date //Timestamp created on logMediaSessionStart event
-    private(set) public var mediaSessionEndTimestamp: Date //Timestamp updated when any event is loggged
+    private(set) public var mediaSessionEndTimestamp: Date //Timestamp updated when any event is logged
     public var mediaTimeSpent: Double {
         get { //total seconds between media session start and current timestamp
             return Date().timeIntervalSince(mediaSessionStartTimestamp)

--- a/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
+++ b/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
@@ -532,6 +532,26 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         XCTAssertTrue(mediaEvent1?.customAttributes == nil)
     }
     
+    func testMediaTimeSpent() {
+        XCTAssertNotNil(mediaSession)
+        
+        // logPlay is triggered to start media content time tracking.
+        mediaSession?.logPlay()
+        // 0.5s delay added to account for the time spent on media content.
+        Thread.sleep(forTimeInterval: 0.5)
+        mediaSession?.logPause()
+        // Another 0.5s delay added after logPause is triggered to
+        // account for time spent on media session (total = +1s).
+        Thread.sleep(forTimeInterval: 0.5)
+        
+        // mediaTimeSpent should be >= 1s event though the last media event logged was 0.5s ago
+        let mediaSessionTimeSpent = mediaSession?.mediaTimeSpent ?? 0.0
+        // the mediaTimeSpent varies in value each test run by a millisecond or two (i,e value is could be 1.001s,
+        // 1.003s, 1.005s and we can't determine the exact value, hence the greaterThanOrEqual and lessThanOrEqual tests.
+        XCTAssertGreaterThanOrEqual(mediaSessionTimeSpent, 1)
+        XCTAssertLessThanOrEqual(mediaSessionTimeSpent, 1.1)
+    }
+    
     func testMediaTimeSpentWhenLogMediaContentEndCalled() {
         XCTAssertNotNil(mediaSession)
         


### PR DESCRIPTION
 ## Summary
 - A customer noticed that the getter for mediaTimeSpent calculates the value based on the difference between mediaSessionEndTimestamp and mediaSessionStartTimestamp, which leads to inaccuracy since mediaSessionEndTimestamp is only updated when logging a media event, with this PR it now calculates based on on the difference between Date() (current time) and mediaSessionStartTimestamp

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E and unit tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7272
