### PR TITLE
fix: Assign correct value for content_type

### DIFF
--- a/mParticle-Apple-Media-SDK/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK/MPMediaSDK.swift
@@ -817,7 +817,7 @@ let PlayerOvp = "player_ovp"
         sessionAttributes[MediaAttributeKeysContentId] = mediaContentId
         sessionAttributes[MediaAttributeKeysDuration] = duration?.stringValue
         sessionAttributes[MediaAttributeKeysStreamType] = MPMediaEvent.mediaStreamTypeString(mediaStreamType:streamType);
-        sessionAttributes[MediaAttributeKeysContentType] = (contentType == MPMediaContentType.video) ? MPMediaContentTypeString.video.rawValue : MPMediaContentTypeString.video.rawValue
+        sessionAttributes[MediaAttributeKeysContentType] = (contentType == MPMediaContentType.video) ? MPMediaContentTypeString.video.rawValue : MPMediaContentTypeString.audio.rawValue
         
         return sessionAttributes
     }

--- a/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
+++ b/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
@@ -148,6 +148,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         XCTAssertEqual(customMPEvent?.type, .media)
         XCTAssertEqual(customMPEvent?.customAttributes?["exampleKey1"] as! String, "exampleValue1")
         XCTAssertEqual(customMPEvent?.customAttributes?["exampleKey2"] as! String, "exampleValue2")
+        XCTAssertEqual(customMPEvent?.customAttributes?["content_type"] as! String, "audio")
     }
     
     func testLogMediaSessionStart() {


### PR DESCRIPTION
 ## Summary
 - A customer pointed out that we forward the contentType always as video even when the value is set to audio, I was able to reproduce and found the culprit code

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E and unit tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7622
