### PR TITLE
feat: update media content time spent calculations with ad breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ let mediaSession = MPMediaSession.init(
     streamType: .onDemand               // Stream Type (OnDemand, Live, etc.)
 )
 
-// OR, optionally exclude ad break time from content time tracking
+// OR, optionally exclude ad break time from content time tracking when using `logAdBreakStart` and `logAdBreakEnd`
 let mediaSession = MPMediaSession.init(
     coreSDK: mParticle,
     mediaContentId: "1234567",

--- a/README.md
+++ b/README.md
@@ -61,12 +61,23 @@ mParticle.start(with: options)
 // Later in your code, when a user begins to engage with your content
 let mediaSession = MPMediaSession.init(
     coreSDK: mParticle,                 // mParticle SDK Instance
-    mediaContentId: '1234567',          // Custom media ID
-    title: 'Funny internet cat video',  // Custom media Title
+    mediaContentId: "1234567",          // Custom media ID
+    title: "Funny internet cat video",  // Custom media Title
     duration: 120000,                   // Duration in milliseconds
     contentType: .video,                // Content Type (Video or Audio)
-    streamType: .onDemand)              // Stream Type (OnDemand, Live, etc.)
+    streamType: .onDemand               // Stream Type (OnDemand, Live, etc.)
+)
 
+// OR, optionally exclude ad break time from content time tracking
+let mediaSession = MPMediaSession.init(
+    coreSDK: mParticle,
+    mediaContentId: "1234567",
+    title: "Funny internet cat video",
+    duration: 120000,
+    contentType: .video,
+    streamType: .onDemand,
+    excludeAdBreaksFromContentTime: true // Optional flag (defaults to false)
+)
 
 mediaSession.logMediaSessionStart()
 mediaSession.logPlay()

--- a/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
@@ -550,7 +550,7 @@ let PlayerOvp = "player_ovp"
     // MARK: ad break
     /// Logs that a sequence of one or more ads has begun
     @objc public func logAdBreakStart(adBreak: MPMediaAdBreak, options: Options?  = nil) {
-        handleAdBreakStartState()
+        self.handleAdBreakStartState()
         
         self.adBreak = adBreak
         let mediaEvent = self.makeMediaEvent(name: .adBreakStart, options: options)
@@ -560,7 +560,7 @@ let PlayerOvp = "player_ovp"
 
     /// Indicates that the ad break is complete
     @objc public func logAdBreakEnd(options: Options?  = nil) {
-        handleAdBreakEndState()
+        self.handleAdBreakEndState()
         
         let mediaEvent = self.makeMediaEvent(name: .adBreakEnd, options: options)
         mediaEvent.adBreak = self.adBreak
@@ -571,21 +571,21 @@ let PlayerOvp = "player_ovp"
     // MARK: private helpers (ad break)
     /// Pause content time tracking if ad-break exclusion is enabled.
     private func handleAdBreakStartState() {
-        guard excludeAdBreaksFromContentTime,
-              currentPlaybackStartTimestamp != nil else { return }
+        guard self.excludeAdBreaksFromContentTime,
+              self.currentPlaybackStartTimestamp != nil else { return }
         
-        storedPlaybackTime += Date().timeIntervalSince(currentPlaybackStartTimestamp!)
-        currentPlaybackStartTimestamp = nil
-        pausedByAdBreak = true
+        self.storedPlaybackTime += Date().timeIntervalSince(self.currentPlaybackStartTimestamp ?? Date())
+        self.currentPlaybackStartTimestamp = nil
+        self.pausedByAdBreak = true
     }
 
     /// Resume content time tracking if previously paused due to ad break.
     private func handleAdBreakEndState() {
-        guard excludeAdBreaksFromContentTime,
-              pausedByAdBreak else { return }
+        guard self.excludeAdBreaksFromContentTime,
+              self.pausedByAdBreak else { return }
         
-        currentPlaybackStartTimestamp = Date()
-        pausedByAdBreak = false
+        self.currentPlaybackStartTimestamp = Date()
+        self.pausedByAdBreak = false
     }
 
     // MARK: ad content

--- a/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
@@ -550,6 +550,12 @@ let PlayerOvp = "player_ovp"
     // MARK: ad break
     /// Logs that a sequence of one or more ads has begun
     @objc public func logAdBreakStart(adBreak: MPMediaAdBreak, options: Options?  = nil) {
+        if excludeAdBreaksFromContentTime, currentPlaybackStartTimestamp != nil {
+            storedPlaybackTime += Date().timeIntervalSince(currentPlaybackStartTimestamp!)
+            currentPlaybackStartTimestamp = nil
+            pausedByAdBreak = true
+        }
+        
         self.adBreak = adBreak
         let mediaEvent = self.makeMediaEvent(name: .adBreakStart, options: options)
         mediaEvent.adBreak = self.adBreak
@@ -558,6 +564,11 @@ let PlayerOvp = "player_ovp"
 
     /// Indicates that the ad break is complete
     @objc public func logAdBreakEnd(options: Options?  = nil) {
+        if excludeAdBreaksFromContentTime, pausedByAdBreak {
+            currentPlaybackStartTimestamp = Date()
+            pausedByAdBreak = false
+        }
+        
         let mediaEvent = self.makeMediaEvent(name: .adBreakEnd, options: options)
         mediaEvent.adBreak = self.adBreak
         self.logEvent(mediaEvent: mediaEvent)

--- a/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
@@ -346,30 +346,6 @@ let PlayerOvp = "player_ovp"
         self.mediaSessionEndTimestamp = currentTimestamp
     }
     
-//    @objc public convenience init(
-//        coreSDK: MParticle?,
-//        mediaContentId: String,
-//        title: String,
-//        duration: NSNumber?,
-//        contentType: MPMediaContentType,
-//        streamType: MPMediaStreamType,
-//        logMPEvents: Bool,
-//        logMediaEvents: Bool,
-//        completeLimit: Int,
-//        excludeAdBreaksFromContentTime: Bool = false
-//    ) {
-//        self.init(coreSDK: coreSDK,
-//                  mediaContentId: mediaContentId,
-//                  title: title,
-//                  duration: duration,
-//                  contentType: contentType,
-//                  streamType: streamType,
-//                  logMPEvents: logMPEvents,
-//                  logMediaEvents: logMediaEvents,
-//                  completeLimit: completeLimit)
-//        self.excludeAdBreaksFromContentTime = excludeAdBreaksFromContentTime
-//    }
-    
     internal convenience init(
         coreSDK: MParticle?,
         mediaContentId: String,
@@ -388,12 +364,12 @@ let PlayerOvp = "player_ovp"
                       duration: duration,
                       contentType: contentType,
                       streamType: streamType,
+                      excludeAdBreaksFromContentTime: excludeAdBreaksFromContentTime,
                       logMPEvents: logMPEvents,
                       logMediaEvents: logMediaEvents,
                       completeLimit: completeLimit)
 
             self.sessionSummarySent = true
-            self.excludeAdBreaksFromContentTime = excludeAdBreaksFromContentTime
     }
     
     deinit {

--- a/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
@@ -339,7 +339,7 @@ let PlayerOvp = "player_ovp"
         if ( 100 >= completeLimit && completeLimit > 0) {
             self.mediaContentCompleteLimit = completeLimit
         }
-        self.excludeAdBreaksFromContentTime = false
+        self.excludeAdBreaksFromContentTime = excludeAdBreaksFromContentTime
         
         let currentTimestamp = Date()
         self.mediaSessionStartTimestamp = currentTimestamp

--- a/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
@@ -549,7 +549,7 @@ let PlayerOvp = "player_ovp"
     // MARK: ad break
     /// Logs that a sequence of one or more ads has begun
     @objc public func logAdBreakStart(adBreak: MPMediaAdBreak, options: Options?  = nil) {
-        self.pauseContentTimeIfAdBreakExclusionEnabled()
+        pauseContentTimeIfAdBreakExclusionEnabled()
         
         self.adBreak = adBreak
         let mediaEvent = self.makeMediaEvent(name: .adBreakStart, options: options)
@@ -559,7 +559,7 @@ let PlayerOvp = "player_ovp"
 
     /// Indicates that the ad break is complete
     @objc public func logAdBreakEnd(options: Options?  = nil) {
-        self.resumeContentTimeIfAdBreakExclusionEnabled()
+        resumeContentTimeIfAdBreakExclusionEnabled()
         
         let mediaEvent = self.makeMediaEvent(name: .adBreakEnd, options: options)
         mediaEvent.adBreak = self.adBreak
@@ -569,14 +569,14 @@ let PlayerOvp = "player_ovp"
     
     // MARK: private helpers (ad break)
     private func pauseContentTimeIfAdBreakExclusionEnabled() {
-        guard self.excludeAdBreaksFromContentTime, self.currentPlaybackStartTimestamp != nil else { return }
-        self.storedPlaybackTime += Date().timeIntervalSince(self.currentPlaybackStartTimestamp!)
-        self.currentPlaybackStartTimestamp = nil
+        guard excludeAdBreaksFromContentTime, currentPlaybackStartTimestamp != nil else { return }
+        storedPlaybackTime += Date().timeIntervalSince(currentPlaybackStartTimestamp!)
+        currentPlaybackStartTimestamp = nil
     }
 
     private func resumeContentTimeIfAdBreakExclusionEnabled() {
-        guard self.excludeAdBreaksFromContentTime, self.currentPlaybackStartTimestamp == nil else { return }
-        self.currentPlaybackStartTimestamp = Date()
+        guard excludeAdBreaksFromContentTime, currentPlaybackStartTimestamp == nil else { return }
+        currentPlaybackStartTimestamp = Date()
     }
 
     // MARK: ad content

--- a/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
@@ -284,7 +284,7 @@ let PlayerOvp = "player_ovp"
     /// :param: duration The playback time of the media content in milliseconds
     /// :param: contentType The type of the media content (e.g. video)
     /// :param: streamType The stream type for the media (e.g. on-demand)
-    @objc public init(coreSDK: MParticle?, mediaContentId: String, title: String, duration: NSNumber?, contentType: MPMediaContentType, streamType: MPMediaStreamType) {
+    @objc public init(coreSDK: MParticle?, mediaContentId: String, title: String, duration: NSNumber?, contentType: MPMediaContentType, streamType: MPMediaStreamType, excludeAdBreaksFromContentTime: Bool = false) {
         if let coreSDK = coreSDK {
             self.coreSDK = coreSDK
         } else {
@@ -296,45 +296,15 @@ let PlayerOvp = "player_ovp"
         self.duration = duration
         self.contentType = contentType
         self.streamType = streamType
+        self.excludeAdBreaksFromContentTime = excludeAdBreaksFromContentTime
         self.mediaSessionId = NSUUID().uuidString
         self.mediaSessionAttributes = [:]
         self.logMPEvents = false
         self.logMediaEvents = true
-        self.excludeAdBreaksFromContentTime = false
         
         let currentTimestamp = Date()
         self.mediaSessionStartTimestamp = currentTimestamp
         self.mediaSessionEndTimestamp = currentTimestamp
-    }
-    
-    /// Creates a media session object. This does not start a session, you can do so by calling `logMediaSessionStart`.
-    /// - Parameters:
-    ///   - coreSDK: The instance of mParticle core SDK to use
-    ///   - mediaContentId: A machine readable identifier representing the current media item
-    ///   - title: Session title
-    ///   - duration: The playback time of the media content in milliseconds
-    ///   - contentType: The type of the media content (e.g. video)
-    ///   - streamType: The stream type for the media (e.g. on-demand)
-    ///   - logMPEvents: Set to true if you would like custom events forwarded to the mParticle SDK
-    ///   - logMediaEvents: Set to true if you would like media events forwarded to the mParticle SDK
-    ///   - completeLimit: Int from 1 to 100 denotes percentage of progress needed to be considered "completed"
-    ///   - excludeAdBreaksFromContentTime: Set to `true` to exclude ad breaks from `mediaContentTimeSpent` calculation
-    @objc public convenience init(
-        coreSDK: MParticle?,
-        mediaContentId: String,
-        title: String,
-        duration: NSNumber?,
-        contentType: MPMediaContentType,
-        streamType: MPMediaStreamType,
-        excludeAdBreaksFromContentTime: Bool
-    ) {
-        self.init(coreSDK: coreSDK,
-                  mediaContentId: mediaContentId,
-                  title: title,
-                  duration: duration,
-                  contentType: contentType,
-                  streamType: streamType)
-        self.excludeAdBreaksFromContentTime = excludeAdBreaksFromContentTime
     }
     
     // MARK: init
@@ -349,7 +319,7 @@ let PlayerOvp = "player_ovp"
     /// :param: logMPEvents Set to true if you would like custom events forwarded to the mParticle SDK
     /// :param: logMediaEvents Set to true if you would like media events forwarded to the mParticle SDK
     /// :param: completeLimit Int from 1 to 100 denotes percentage of progress needed to be considered "completed"
-    @objc public init(coreSDK: MParticle?, mediaContentId: String, title: String, duration: NSNumber?, contentType: MPMediaContentType, streamType: MPMediaStreamType, logMPEvents: Bool, logMediaEvents: Bool, completeLimit: Int) {
+    @objc public init(coreSDK: MParticle?, mediaContentId: String, title: String, duration: NSNumber?, contentType: MPMediaContentType, streamType: MPMediaStreamType, excludeAdBreaksFromContentTime: Bool = false, logMPEvents: Bool, logMediaEvents: Bool, completeLimit: Int) {
         if let coreSDK = coreSDK {
             self.coreSDK = coreSDK
         } else {
@@ -361,6 +331,7 @@ let PlayerOvp = "player_ovp"
         self.duration = duration
         self.contentType = contentType
         self.streamType = streamType
+        self.excludeAdBreaksFromContentTime = excludeAdBreaksFromContentTime
         self.mediaSessionId = NSUUID().uuidString
         self.mediaSessionAttributes = [:]
         self.logMPEvents = logMPEvents
@@ -375,29 +346,29 @@ let PlayerOvp = "player_ovp"
         self.mediaSessionEndTimestamp = currentTimestamp
     }
     
-    @objc public convenience init(
-        coreSDK: MParticle?,
-        mediaContentId: String,
-        title: String,
-        duration: NSNumber?,
-        contentType: MPMediaContentType,
-        streamType: MPMediaStreamType,
-        logMPEvents: Bool,
-        logMediaEvents: Bool,
-        completeLimit: Int,
-        excludeAdBreaksFromContentTime: Bool
-    ) {
-        self.init(coreSDK: coreSDK,
-                  mediaContentId: mediaContentId,
-                  title: title,
-                  duration: duration,
-                  contentType: contentType,
-                  streamType: streamType,
-                  logMPEvents: logMPEvents,
-                  logMediaEvents: logMediaEvents,
-                  completeLimit: completeLimit)
-        self.excludeAdBreaksFromContentTime = excludeAdBreaksFromContentTime
-    }
+//    @objc public convenience init(
+//        coreSDK: MParticle?,
+//        mediaContentId: String,
+//        title: String,
+//        duration: NSNumber?,
+//        contentType: MPMediaContentType,
+//        streamType: MPMediaStreamType,
+//        logMPEvents: Bool,
+//        logMediaEvents: Bool,
+//        completeLimit: Int,
+//        excludeAdBreaksFromContentTime: Bool = false
+//    ) {
+//        self.init(coreSDK: coreSDK,
+//                  mediaContentId: mediaContentId,
+//                  title: title,
+//                  duration: duration,
+//                  contentType: contentType,
+//                  streamType: streamType,
+//                  logMPEvents: logMPEvents,
+//                  logMediaEvents: logMediaEvents,
+//                  completeLimit: completeLimit)
+//        self.excludeAdBreaksFromContentTime = excludeAdBreaksFromContentTime
+//    }
     
     internal convenience init(
         coreSDK: MParticle?,

--- a/mParticle-Apple-Media-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-Media-SDK.xcodeproj/project.pbxproj
@@ -247,7 +247,7 @@
 				};
 			};
 			buildConfigurationList = DBD815E22319A7F400A9809C /* Build configuration list for PBXProject "mParticle-Apple-Media-SDK" */;
-			compatibilityVersion = "Xcode 9.3";
+			compatibilityVersion = "Xcode 12.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
+++ b/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
@@ -418,6 +418,73 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         mediaSession?.logAdBreakEnd()
         self.waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
+    
+    func testAdBreakExclusionDisabledDoesNotPauseContentTime() {
+        let adBreak = MPMediaAdBreak(title: "foo adbreak title", id: "12345")
+        mediaSession?.excludeAdBreaksFromContentTime = false
+
+        // Start content playback and accumulate 0.2s before the ad break
+        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0)
+        mediaSession?.logPlay()
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        XCTAssertNotNil(mediaSession?.currentPlaybackStartTimestamp)
+        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0.2, accuracy: 0.08)
+
+        // 0.2s should count toward content time.
+        mediaSession?.logAdBreakStart(adBreak: adBreak)
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0.4, accuracy: 0.08)
+        
+        mediaSession?.logAdBreakEnd()
+        XCTAssertNil(mediaSession?.adBreak)
+
+        mediaSession?.logPause()
+        
+        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0.4, accuracy: 0.08)
+        XCTAssertNil(mediaSession?.currentPlaybackStartTimestamp)
+    }
+    
+    func testAdBreakExclusionEnabledExcludesAdTime() {
+        let adBreak = MPMediaAdBreak(title: "foo adbreak title", id: "12345")
+        mediaSession?.excludeAdBreaksFromContentTime = true
+
+        // Start content playback and accumulate 0.2s before the ad break
+        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0)
+        mediaSession?.logPlay()
+        Thread.sleep(forTimeInterval: 0.2)
+
+        XCTAssertNotNil(mediaSession?.currentPlaybackStartTimestamp)
+        XCTAssertEqual(mediaSession!.storedPlaybackTime, 0)
+        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0.2, accuracy: 0.08)
+
+        // Start ad break content time should pause & be stored
+        mediaSession?.logAdBreakStart(adBreak: adBreak)
+        Thread.sleep(forTimeInterval: 0.2)
+
+        // Content tracking paused: playhead cleared, stored captured 0.2s
+        XCTAssertEqual(mediaSession!.storedPlaybackTime, mediaSession!.mediaContentTimeSpent)
+        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0.2, accuracy: 0.08)
+        XCTAssertNil(mediaSession?.currentPlaybackStartTimestamp)
+
+        // End ad break auto-resume content tracking
+        mediaSession?.logAdBreakEnd()
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        XCTAssertEqual(mediaSession!.storedPlaybackTime, 0.2, accuracy: 0.08)
+        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0.4, accuracy: 0.08)
+        XCTAssertNotNil(mediaSession?.currentPlaybackStartTimestamp)
+        XCTAssertNil(mediaSession?.adBreak)
+
+        // Watch a bit more content after the ad
+        Thread.sleep(forTimeInterval: 0.2)
+
+        mediaSession?.logPause()
+
+        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0.6, accuracy: 0.08)
+        XCTAssertNil(mediaSession?.currentPlaybackStartTimestamp)
+    }
 
     func testLogSegmentStart() {
         let segment = MPMediaSegment(title: "foo segment title", index: 3, duration: 30000)

--- a/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
+++ b/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
@@ -79,7 +79,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
         coreSDK = MParticle.sharedInstance()
-        mediaSession = MPMediaSession(coreSDK: coreSDK, mediaContentId: "12345", title: "foo title", duration: 90000, contentType: .video, streamType: .onDemand, logMPEvents: false, logMediaEvents: true, completeLimit: 90, testing: true)
+        mediaSession = MPMediaSession(coreSDK: coreSDK, mediaContentId: "12345", title: "foo title", duration: 90000, contentType: .video, streamType: .onDemand, logMPEvents: false, logMediaEvents: true, completeLimit: 90, excludeAdBreaksFromContentTime: true, testing: true)
         MPListenerController.sharedInstance().addSdkListener(self)
     }
 
@@ -102,6 +102,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         XCTAssertEqual(mediaSession?.streamType, .onDemand)
         XCTAssertTrue(mediaSession?.mediaSessionAttributes != nil)
         XCTAssertTrue(mediaSession?.mediaSessionAttributes.count == 0)
+        XCTAssertTrue(mediaSession!.excludeAdBreaksFromContentTime)
         
         let mediaEvent1 = mediaSession?.makeMediaEvent(name: .play)
         
@@ -113,7 +114,7 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         XCTAssertEqual(mediaEvent1?.streamType, .onDemand)
         XCTAssertTrue(mediaEvent1?.customAttributes == nil)
 
-        mediaSession = MPMediaSession(coreSDK: coreSDK, mediaContentId: "678", title: "foo title 2", duration: 80000, contentType: .audio, streamType: .liveStream, logMPEvents: true, logMediaEvents: false, completeLimit: 90, testing: true)
+        mediaSession = MPMediaSession(coreSDK: coreSDK, mediaContentId: "678", title: "foo title 2", duration: 80000, contentType: .audio, streamType: .liveStream, logMPEvents: true, logMediaEvents: false, completeLimit: 90, excludeAdBreaksFromContentTime: true, testing: true)
         mediaSession?.mediaSessionAttributes = ["exampleKey1": "exampleValue1"]
 
         XCTAssertTrue(mediaSession!.logMPEvents, "logMPEvents should have been set to true")
@@ -125,6 +126,8 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         XCTAssertEqual(mediaSession?.streamType, .liveStream)
         XCTAssertEqual(mediaSession?.mediaSessionAttributes["exampleKey1"] as! String, "exampleValue1")
         XCTAssertTrue(mediaSession?.mediaSessionAttributes.count == 1)
+        XCTAssertTrue(mediaSession!.excludeAdBreaksFromContentTime)
+        
         
         let mediaEvent2 = mediaSession?.makeMediaEvent(name: .play)
         

--- a/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
+++ b/mParticle-Apple-Media-SDKTests/mParticle_Apple_MediaTests.swift
@@ -429,20 +429,20 @@ class mParticle_Apple_MediaTests: XCTestCase, MPListenerProtocol {
         Thread.sleep(forTimeInterval: 0.2)
         
         XCTAssertNotNil(mediaSession?.currentPlaybackStartTimestamp)
-        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0.2, accuracy: 0.08)
+        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0.2, accuracy: 0.1)
 
         // 0.2s should count toward content time.
         mediaSession?.logAdBreakStart(adBreak: adBreak)
         Thread.sleep(forTimeInterval: 0.2)
         
-        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0.4, accuracy: 0.08)
+        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0.4, accuracy: 0.1)
         
         mediaSession?.logAdBreakEnd()
         XCTAssertNil(mediaSession?.adBreak)
 
         mediaSession?.logPause()
         
-        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0.4, accuracy: 0.08)
+        XCTAssertEqual(mediaSession!.mediaContentTimeSpent, 0.4, accuracy: 0.1)
         XCTAssertNil(mediaSession?.currentPlaybackStartTimestamp)
     }
     


### PR DESCRIPTION
## Background
- Per this [doc](https://docs.google.com/document/d/1nc1v1JoGBR21F_kBJQgwFhWauw4sfswWLXoIaZs0iO4/edit?tab=t.0#heading=h.klilr1f259te), Currently, the mParticle Media SDK requires developers to manually manage content time tracking during ad breaks, creating additional complexity and potential for error. If not managed appropriately, the media content time spent value is overstated with ad break time. This PR adds an (optional) ability to allow pausing mediaContentTimeSpent when an Ad Break starts and ends

## What Has Changed
- Added `excludeAdBreaksFromContentTime` flag to `MPMediaSession`.
- Updated `logAdBreakStart` and `logAdBreakEnd` to pause/resume content time tracking when the flag is enabled.
- Added private helpers `pauseContentTimeIfAdBreakExclusionEnabled()` and `resumeContentTimeIfAdBreakExclusionEnabled()`.
- Added unit tests for flag behavior and time exclusion accuracy.

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
- Related to https://github.com/mParticle/mparticle-web-media-sdk/pull/777
- Same feature will be added to Android and Roku

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://rokt.atlassian.net/browse/SDKE-447
