### PR TITLE
feat: adjust ad break exclusion logic

### DIFF
--- a/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
@@ -688,29 +688,31 @@ let PlayerOvp = "player_ovp"
     }
     
     private func logAdSummary() {
-        if (self.adContent != nil) {
-            if (self.adContent?.adStartTimestamp != nil) {
-                self.adContent?.adEndTimestamp = Date()
-                self.mediaTotalAdTimeSpent += self.adContent!.adEndTimestamp!.timeIntervalSince(self.adContent!.adStartTimestamp!)
-            }
-            
-            let event = MPEvent.init(name: MPAdSummary, type: .media)!
-            let mediaEvent = self.makeMediaEvent(name: .adSessionSummary, options: nil)
-            
-            var customAttributes: [String:Any] = mediaEvent.getEventAttributes()
-            customAttributes[adBreakIdKey] = self.adBreak?.id
-            customAttributes[adContentIdKey] = self.adContent?.id
-            customAttributes[adContentStartTimestampKey] = self.adContent?.adStartTimestamp
-            customAttributes[adContentEndTimestampKey] = self.adContent?.adEndTimestamp
-            customAttributes[adContentTitleKey] = self.adContent?.title
-            customAttributes[adContentSkippedKey] = self.adContent?.adSkipped
-            customAttributes[adContentCompletedKey] = self.adContent?.adCompleted
-            
-            event.customAttributes = customAttributes
-            coreSDK.logEvent(event)
-            
-            self.adContent = nil
+        guard let adContent = adContent,
+              let start = adContent.adStartTimestamp else { return }
+        
+        if adContent.adEndTimestamp == nil {
+            let end = Date()
+            self.adContent?.adEndTimestamp = end
+            mediaTotalAdTimeSpent += end.timeIntervalSince(start)
         }
+        
+        let event = MPEvent.init(name: MPAdSummary, type: .media)!
+        let mediaEvent = self.makeMediaEvent(name: .adSessionSummary, options: nil)
+        
+        var customAttributes: [String:Any] = mediaEvent.getEventAttributes()
+        customAttributes[adBreakIdKey] = adBreak?.id
+        customAttributes[adContentIdKey] = adContent.id
+        customAttributes[adContentStartTimestampKey] = adContent.adStartTimestamp
+        customAttributes[adContentEndTimestampKey] = adContent.adEndTimestamp
+        customAttributes[adContentTitleKey] = adContent.title
+        customAttributes[adContentSkippedKey] = adContent.adSkipped
+        customAttributes[adContentCompletedKey] = adContent.adCompleted
+        
+        event.customAttributes = customAttributes
+        coreSDK.logEvent(event)
+        
+        self.adContent = nil
     }
 }
 

--- a/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
@@ -339,7 +339,6 @@ let PlayerOvp = "player_ovp"
         if ( 100 >= completeLimit && completeLimit > 0) {
             self.mediaContentCompleteLimit = completeLimit
         }
-        self.excludeAdBreaksFromContentTime = excludeAdBreaksFromContentTime
         
         let currentTimestamp = Date()
         self.mediaSessionStartTimestamp = currentTimestamp

--- a/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
+++ b/mParticle-Apple-Media-SDK-Shared/MPMediaSDK.swift
@@ -697,13 +697,14 @@ let PlayerOvp = "player_ovp"
     }
     
     private func logAdSummary() {
-        guard let adContent = adContent,
-              let start = adContent.adStartTimestamp else { return }
+        guard let adContent = adContent else { return }
         
-        if adContent.adEndTimestamp == nil {
-            let end = Date()
-            self.adContent?.adEndTimestamp = end
-            mediaTotalAdTimeSpent += end.timeIntervalSince(start)
+        if let start = adContent.adStartTimestamp {
+            if adContent.adEndTimestamp == nil {
+                let end = Date()
+                adContent.adEndTimestamp = end
+                mediaTotalAdTimeSpent += end.timeIntervalSince(start)
+            }
         }
         
         let event = MPEvent.init(name: MPAdSummary, type: .media)!


### PR DESCRIPTION
## Background
- Previously, the SDK could auto-resume content when it shouldn’t and double-count ad time. This caused inaccurate analytics for customers using ad-break exclusion.

## What Has Changed
- Added a playback state machine to correctly determine whether content should pause or resume during ad breaks.
- Fixed double-counting of ad time in logAdSummary.
- Cleaned up redundant initializer logic and improved internal helper behavior.

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://rokt.atlassian.net/browse/SDKE-600
