### PR TITLE
ci: Move Github Release Action to Final Step

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -39,16 +39,15 @@ jobs:
       - name: Install CocoaPods
         run: gem install cocoapods
 
-      - name: Create Github release
-        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0
-        with:
-          makeLatest: true
-          tag: ${{ steps.version-file.outputs.release-version }}
-          generateReleaseNotes: true
-
       - name: Push to Trunk
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
           pod trunk push --allow-warnings mParticle-Apple-Media-SDK.podspec
 
+      - name: Create Github release
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0
+        with:
+          makeLatest: true
+          tag: ${{ steps.version-file.outputs.release-version }}
+          generateReleaseNotes: true


### PR DESCRIPTION
## Background
The release workflow previously created the GitHub release before pushing to CocoaPods Trunk. This meant that if the Trunk push failed, the GitHub release would already be created, making it harder to retry the release process.

## What Has Changed
- Swapped the order of "Push to Trunk" and "Create Github release" steps in the `release-from-main.yml` workflow
- CocoaPods Trunk push now happens first, followed by GitHub release creation
- This ensures that if the Trunk push fails, the GitHub release won't be created yet, simplifying retry logic

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes NO-JIRA