### PR TITLE
docs: update README for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ mediaSession.logPause(options: options)
 
 The following example demonstrates how to import and use the Apple Media SDK in an Objective-C project. It shows the correct module and header import statements depending on your build setup.
 
-For apps supporting iOS 15.6 and above, Apple recommends using the import syntax for **modules** or **semantic import**.
-
 If you are using mParticle as a framework, your import statement will be as follows:
 
 ```objective-c

--- a/README.md
+++ b/README.md
@@ -18,7 +18,15 @@ Please be aware that this SDK is built as an extension of and requires the use o
 
 ## Get the SDK
 
-The mParticle-Apple-Media-SDK is available via [CocoaPods](https://cocoapods.org/?q=mparticle) or [Swift Package Manager](https://github.com/swiftlang/swift-package-manager). Follow the instructions below based on your preference.
+The mParticle-Apple-Media-SDK is available via [Swift Package Manager](https://github.com/swiftlang/swift-package-manager) or [CocoaPods](https://cocoapods.org/?q=mparticle). Follow the instructions below based on your preference.
+
+#### Swift Package Manager
+
+To integrate the SDK using Swift Package Manager, open your Xcode project and click on your project in the file list on the left, click on your Project name in the middle of the window, click on the "Package Dependencies" tab, and click the "+" button underneath the Packages list.
+
+Enter the repository URL `https://github.com/mParticle/mparticle-apple-media-sdk` in the search box on the top right, choose `mparticle-apple-media-sdk` from the list of packages, and change "Dependency Rule" to "Up to Next Major Version". Then click the "Add Package" button on the bottom right.
+
+Select the `mParticle-Apple-Media-SDK` package product and click "Add Package".
 
 #### CocoaPods
 
@@ -29,14 +37,6 @@ target '<Your Target>' do
     pod 'mParticle-Apple-Media-SDK', '~> 2.0'
 end
 ```
-
-#### Swift Package Manager
-
-To integrate the SDK using Swift Package Manager, open your Xcode project and click on your project in the file list on the left, click on your Project name in the middle of the window, click on the "Package Dependencies" tab, and click the "+" button underneath the Packages list.
-
-Enter the repository URL `https://github.com/mParticle/mparticle-apple-media-sdk` in the search box on the top right, choose `mparticle-apple-media-sdk` from the list of packages, and change "Dependency Rule" to "Up to Next Major Version". Then click the "Add Package" button on the bottom right.
-
-Select the `mParticle-Apple-Media-SDK` package product and click "Add Package".
 
 ## Include and Initialize the SDK
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To integrate the Media SDK using CocoaPods, specify it in your Podfile:
 
 ```ruby
 target '<Your Target>' do
-    pod 'mParticle-Apple-Media-SDK', '~> 1.0'
+    pod 'mParticle-Apple-Media-SDK', '~> 2.0'
 end
 ```
 
@@ -87,7 +87,7 @@ mediaSession.logPause(options: options)
 
 The following example demonstrates how to import and use the Apple Media SDK in an Objective-C project. It shows the correct module and header import statements depending on your build setup.
 
-For apps supporting iOS 8 and above, Apple recommends using the import syntax for **modules** or **semantic import**.
+For apps supporting iOS 15.6 and above, Apple recommends using the import syntax for **modules** or **semantic import**.
 
 If you are using mParticle as a framework, your import statement will be as follows:
 


### PR DESCRIPTION
## Background

The README contained stale references from v1.x that were not updated when v2.0.0 was released.

## What Has Changed

- Updated CocoaPods version pin from `~> 1.0` to `~> 2.0`
- Updated minimum iOS version reference in the Objective-C section from iOS 8 to iOS 15.6 to reflect the new deployment target

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes NO-JIRA