### PR TITLE
fix: bump SPM min platform to iOS/tvOS 15.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "mParticle-Apple-Media-SDK",
-    platforms: [.iOS(.v15), .tvOS(.v15)],
+    platforms: [.iOS("15.6"), .tvOS("15.6")],
     products: [
         .library(
             name: "mParticle-Apple-Media-SDK",

--- a/mParticle-Apple-Media-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-Media-SDK.xcodeproj/project.pbxproj
@@ -293,7 +293,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -352,7 +352,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -383,7 +383,7 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Carthage/Build/iOS/mParticle_Apple_SDK.framework/Headers/**";
 				INFOPLIST_FILE = "mParticle-Apple-Media-SDK/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -418,7 +418,7 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Carthage/Build/iOS/mParticle_Apple_SDK.framework/Headers/**";
 				INFOPLIST_FILE = "mParticle-Apple-Media-SDK/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -445,7 +445,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "mParticle-Apple-Media-SDKTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -471,7 +471,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "mParticle-Apple-Media-SDKTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Summary

The SwiftPM manifest declared a minimum deployment target of `.iOS(.v15)` / `.tvOS(.v15)` (i.e. 15.0), but the mParticle Apple Core SDK `9.x` requires **iOS/tvOS 15.6**. This mismatch caused SwiftPM dependency resolution to fail when consuming this package against `mParticle-Apple-SDK` 9.2.2.

This PR aligns the SPM platform minimums with the version already declared in [`mParticle-Apple-Media-SDK.podspec`](https://github.com/mParticle/mparticle-apple-media-sdk/blob/main/mParticle-Apple-Media-SDK.podspec), which has correctly specified `15.6` for both platforms:

```ruby
s.ios.deployment_target = "15.6"
s.tvos.deployment_target = "15.6"
```

## Change

```diff
-    platforms: [.iOS(.v15), .tvOS(.v15)],
+    platforms: [.iOS("15.6"), .tvOS("15.6")],
```

## Validation

- `swift package dump-package` parses successfully.
- SPM minimums now match the podspec (15.6) and the Core SDK's requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)