### PR TITLE
revert: roll back minimum iOS/tvOS deployment target to 15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Revert minimum iOS/tvOS deployment target back to 15.0 (reverts #38)
+
 ## [2.0.1] - 2026-06-30
 
 ### Fixed

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "mParticle-Apple-Media-SDK",
-    platforms: [.iOS("15.6"), .tvOS("15.6")],
+    platforms: [.iOS(.v15), .tvOS(.v15)],
     products: [
         .library(
             name: "mParticle-Apple-Media-SDK",

--- a/mParticle-Apple-Media-SDK.podspec
+++ b/mParticle-Apple-Media-SDK.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
 
     s.swift_version = '5.0'
 
-    s.ios.deployment_target = "15.6"
-    s.tvos.deployment_target = "15.6"
+    s.ios.deployment_target = "15.0"
+    s.tvos.deployment_target = "15.0"
 
     s.source_files = [
       'mParticle-Apple-Media-SDK/**/*.{h,m,swift}'

--- a/mParticle-Apple-Media-SDK.xcodeproj/project.pbxproj
+++ b/mParticle-Apple-Media-SDK.xcodeproj/project.pbxproj
@@ -293,7 +293,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -352,7 +352,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -383,7 +383,7 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Carthage/Build/iOS/mParticle_Apple_SDK.framework/Headers/**";
 				INFOPLIST_FILE = "mParticle-Apple-Media-SDK/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -418,7 +418,7 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Carthage/Build/iOS/mParticle_Apple_SDK.framework/Headers/**";
 				INFOPLIST_FILE = "mParticle-Apple-Media-SDK/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -445,7 +445,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "mParticle-Apple-Media-SDKTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -471,7 +471,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "mParticle-Apple-Media-SDKTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Summary

- Reverts #38 — rolls the minimum iOS and tvOS deployment target back to 15.0 across `Package.swift`, `mParticle-Apple-Media-SDK.podspec`, and Xcode project files
- Aligns with the ecosystem-wide rollback of the 15.6 minimum OS bump
- Adds an Unreleased CHANGELOG entry documenting the revert

## Test plan

- [ ] Verify `Package.swift` uses `.iOS(.v15), .tvOS(.v15)`
- [ ] Verify `mParticle-Apple-Media-SDK.podspec` has `deployment_target = "15.0"` for iOS and tvOS
- [ ] Verify no `15.6` references remain in project files
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)